### PR TITLE
Fix permissions of init scripts to 755 for correct execution

### DIFF
--- a/rpm/SPECS/iscsi-ha.spec
+++ b/rpm/SPECS/iscsi-ha.spec
@@ -54,6 +54,7 @@ echo "Setting up iscsi-ha..."
 
 # Set executable permissions
 find %{_sysconfdir}/iscsi-ha -type f -name "*.sh" -exec chmod +x {} \;
+find %{_sysconfdir}/iscsi-ha/init -type f -exec chmod +x {} \;
 find %{_sysconfdir}/iscsi-ha/scripts -type f -exec chmod +x {} \;
 # Add CLI link
 ln -sf %{_sysconfdir}/iscsi-ha/scripts/iscsi-ha /usr/bin/iscsi-ha || true


### PR DESCRIPTION
## Description

Fixed the permissions of init scripts to 755 to ensure they are executable by the system. This change resolves issues where the scripts were not running due to incorrect permissions.

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read the project's CONTRIBUTING.md.
- [x] I have verified that my changes work as expected.
- [x] All tests pass locally.

